### PR TITLE
Awakened Completion Areas & ServerData MonsterLevel MonsterRemaining

### DIFF
--- a/Core/PoEMemory/MemoryObjects/ServerData.cs
+++ b/Core/PoEMemory/MemoryObjects/ServerData.cs
@@ -266,6 +266,7 @@ namespace ExileCore.PoEMemory.MemoryObjects
         public IList<WorldArea> CompletedAreas => GetAreas(ServerDataStruct.CompletedMaps);
         public IList<WorldArea> ShapedMaps => new List<WorldArea>();// GetAreas(ServerDataStruct.ShapedAreas);
         public IList<WorldArea> BonusCompletedAreas => GetAreas(ServerDataStruct.BonusCompletedAreas);
+        public IList<WorldArea> AwakenedAreas => GetAreas(ServerDataStruct.AwakenedAreas);
         public IList<WorldArea> ElderGuardiansAreas => new List<WorldArea>();// GetAreas(ServerDataStruct.ElderGuardiansAreas);
         public IList<WorldArea> MasterAreas => new List<WorldArea>();// GetAreas(ServerDataStruct.MasterAreas);
         public IList<WorldArea> ShaperElderAreas => new List<WorldArea>();// GetAreas(ServerDataStruct.ElderInfluencedAreas);

--- a/GameOffsets/ActorComponentOffsets.cs
+++ b/GameOffsets/ActorComponentOffsets.cs
@@ -23,7 +23,7 @@ namespace GameOffsets
         [FieldOffset(0x650)] public NativePtrArray ActorSkillsArray;
 
         // Broken Offset, remove comment on fixup.
-        [FieldOffset(0x540)] public NativePtrArray ActorVaalSkills;
+        [FieldOffset(0x680)] public NativePtrArray ActorVaalSkills;
         [FieldOffset(0x578)] public NativePtrArray HasMinionArray;
 
         [FieldOffset(0x6A0)] public NativePtrArray DeployedObjectArray;

--- a/GameOffsets/ServerDataOffsets.cs
+++ b/GameOffsets/ServerDataOffsets.cs
@@ -55,8 +55,8 @@ namespace GameOffsets
 		[FieldOffset(0x7AB8 - Skip)] public long CompletedMaps;//search for a LONG value equals to your current amount of completed maps. Pointer will be under this offset
         [FieldOffset(0x7AF8 - Skip)] public long BonusCompletedAreas;
         [FieldOffset(0x7B38 - Skip)] public long AwakenedAreas;
-        [FieldOffset(0x85E4 - Skip)] public byte MonsterLevel;
-        [FieldOffset(0x85e5 - Skip)] public byte MonstersRemaining;
+        [FieldOffset(0x85EC - Skip)] public byte MonsterLevel;
+        [FieldOffset(0x85ED - Skip)] public byte MonstersRemaining;
         [FieldOffset(0x86A0 - Skip)] public ushort CurrentSulphiteAmount; //Maybe wrong not tested
         [FieldOffset(0x86A4 - Skip)] public int CurrentAzuriteAmount;
     }


### PR DESCRIPTION
Offsets in struct were already valid for awakened completion
Level and Remaining moved +0x08